### PR TITLE
move setdefaulttimeout line to before open socket

### DIFF
--- a/python/port_scanner.py
+++ b/python/port_scanner.py
@@ -16,8 +16,8 @@ print('-' * 50)
 
 try:
   for port in range(1,65535):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     socket.setdefaulttimeout(0.5)
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     result = s.connect_ex((target, port))
     if result == 0:
       print("port {} is open".format(port))


### PR DESCRIPTION
We have to put setdefaulttimeout(0.5) before open socket. Otherwise computer will wait for default timeout to check first unavailable port number.