### PR TITLE
Remove Udemy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Compilation of Resources from TCM's Udemy Course
 
 Link to Website: https://www.thecybermentor.com/
 
-Links to course: 
-* https://www.udemy.com/course/practical-ethical-hacking/ (udemy)
+Link to the course: 
 * https://academy.tcm-sec.com/p/practical-ethical-hacking-the-complete-course (tcm academy)
 
 Link to discord server: https://discord.gg/EM6tqPZ


### PR DESCRIPTION
As the course has been moved from Udemy, I guessed the link should be removed